### PR TITLE
ci: Add PDF-diff commenting to PR workflow

### DIFF
--- a/.github/workflows/kibot_diff.yml
+++ b/.github/workflows/kibot_diff.yml
@@ -1,0 +1,70 @@
+name: Comment with PDF-diff
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  comment-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # So we can run a diff between changes
+          fetch-depth: '0'
+
+      # Update the diff.kibot.yaml file to diff against the correct base branch of the pull request
+      - name: Update base branch in diff.kibot.yaml
+        run: |
+          sed -i "s/HEAD~/${{ github.event.pull_request.base.sha }}/g" kicad/diff.kibot.yaml
+
+      - name: Run KiBot
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          config: kicad/diff.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+          # optional - schematic file
+          schema: 'kicad/bms-c1.kicad_sch'
+          # optional - PCB design file
+          board: 'kicad/bms-c1.kicad_pcb'
+
+      - name: Upload pcb
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-pcb
+        with:
+          name: bms-c1-diff_pcb.pdf.pdf
+          path: output/diff/bms-c1-diff_pcb.pdf
+
+      - name: Upload schematic
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-sch
+        with:
+          name: bms-c1-diff_sch.pdf
+          path: output/diff/bms-c1-diff_sch.pdf
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-regex: 'Diff between .* \(\S+\) and .* \(\S+\):'
+
+      - name: Prepare variables for comment body
+        id: comment-body
+        run: |
+          echo "base_short=$(git rev-parse --short ${{ github.event.pull_request.base.sha }})" >> "$GITHUB_OUTPUT"
+          echo "head_short=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Diff between ${{ github.event.pull_request.base.ref }} (${{ steps.comment-body.outputs.base_short }}) and ${{ github.event.pull_request.head.ref }} (${{ steps.comment-body.outputs.head_short }}):
+            - [bms-c1-diff_sch.pdf](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-sch.outputs.artifact-id }})
+            - [bms-c1-diff_pcb.pdf](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-pcb.outputs.artifact-id }})
+          edit-mode: replace

--- a/kicad/diff.kibot.yaml
+++ b/kicad/diff.kibot.yaml
@@ -1,0 +1,26 @@
+kibot:
+  version: 1
+
+outputs:
+- name: basic_diff_pcb
+  comment: PCB diff between the last two changes
+  type: diff
+  dir: diff
+  layers: all
+  options:
+    old: HEAD~
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+- name: basic_diff_sch
+  comment: Schematic diff between the last two changes
+  type: diff
+  dir: diff
+  options:
+    old: HEAD~
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+    pcb: false


### PR DESCRIPTION
- Activates on pull request actions including opened, synchronized, reopened, and edited events.
- Includes a checkout step with full fetch depth to enable comprehensive diffs.
- Dynamically updates the KiBot configuration to reference the correct base branch of the pull request.
- Utilizes KiBot action for generating PCB and schematic differences, specifying configuration, output directory, and file paths.
- Uploads the resultant PCB and schematic PDFs as artifacts, using distinct names for easy identification.
- Employs 'find-comment' action to search for an existing comment made by github-actions[bot] and matches a specific regex pattern.
- Prepares short SHA values of base and head commits for comment inclusion.
- Creates or updates a PR comment with links to the diff PDFs, providing clear and accessible diff comparisons directly in the PR.