### PR TITLE
ci: Add PDF-diff commenting to PR workflow

### DIFF
--- a/.github/workflows/kibot_diff.yml
+++ b/.github/workflows/kibot_diff.yml
@@ -1,0 +1,69 @@
+name: Run PDF-diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  run-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # So we can run a diff between changes
+          fetch-depth: '0'
+
+      # Update the diff.kibot.yaml file to diff against the correct base branch of the pull request
+      - name: Update base branch in diff.kibot.yaml
+        run: |
+          sed -i "s/HEAD~/${{ github.event.pull_request.base.sha }}/g" kicad/diff.kibot.yaml
+
+      - name: Run KiBot
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          config: kicad/diff.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+          # optional - schematic file
+          schema: 'kicad/bms-c1.kicad_sch'
+          # optional - PCB design file
+          board: 'kicad/bms-c1.kicad_pcb'
+
+      - name: Upload pcb
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-pcb
+        with:
+          name: bms-c1-diff_pcb.pdf.pdf
+          path: output/diff/bms-c1-diff_pcb.pdf
+
+      - name: Upload schematic
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step-sch
+        with:
+          name: bms-c1-diff_sch.pdf
+          path: output/diff/bms-c1-diff_sch.pdf
+
+      - name: Prepare variables for comment body
+        id: comment-body
+        run: |
+          echo "base_short=$(git rev-parse --short ${{ github.event.pull_request.base.sha }})" >> "$GITHUB_OUTPUT"
+          echo "head_short=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> "$GITHUB_OUTPUT"
+
+      - name: 'Prepare artifact for transfer'
+        run: |
+          # Save ENV for transfer
+          echo "PR_BASE_SHORT=${{ steps.comment-body.outputs.base_short }}" >> pr.env
+          echo "PR_HEAD_SHORT=${{ steps.comment-body.outputs.head_short }}" >> pr.env
+          echo "PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> pr.env
+          echo "PR_HEAD_REF=${{ github.event.pull_request.head.ref }}" >> pr.env
+          echo "PR_LINK_SCH=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-sch.outputs.artifact-id }}" >> pr.env
+          echo "PR_LINK_PCB=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step-pcb.outputs.artifact-id }}" >> pr.env
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> pr.env
+
+      - name: 'Upload artifact for workflow transfer'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr.env
+          retention-days: 1

--- a/kicad/diff.kibot.yaml
+++ b/kicad/diff.kibot.yaml
@@ -1,0 +1,26 @@
+kibot:
+  version: 1
+
+outputs:
+- name: basic_diff_pcb
+  comment: PCB diff between the last two changes
+  type: diff
+  dir: diff
+  layers: all
+  options:
+    old: HEAD~
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+- name: basic_diff_sch
+  comment: Schematic diff between the last two changes
+  type: diff
+  dir: diff
+  options:
+    old: HEAD~
+    old_type: git
+    new: HEAD
+    new_type: git
+    add_link_id: true
+    pcb: false


### PR DESCRIPTION
- Activates on pull request actions including opened, synchronized, reopened, and edited events.
- Includes a checkout step with full fetch depth to enable comprehensive diffs.
- Dynamically updates the KiBot configuration to reference the correct base branch of the pull request.
- Utilizes KiBot action for generating PCB and schematic differences, specifying configuration, output directory, and file paths.
- Uploads the resultant PCB and schematic PDFs as artifacts, using distinct names for easy identification.
- Employs 'find-comment' action to search for an existing comment made by github-actions[bot] and matches a specific regex pattern.
- Prepares short SHA values of base and head commits for comment inclusion.
- Creates or updates a PR comment with links to the diff PDFs, providing clear and accessible diff comparisons directly in the PR.